### PR TITLE
Feature/spinbutton

### DIFF
--- a/docs/views/Main.vue
+++ b/docs/views/Main.vue
@@ -11,6 +11,9 @@
                            :max="parseInt(ipm_max)"
                            :step="parseInt(ipm_step)"
                            :vertical="ipm_vertical"
+                           :increment-aria-label="'increase by 1'"
+                           :decrement-aria-label="'decrease by 1'"
+                           :spinButtonAriaLabel="'first example'"
                            v-model="ipm_value">
                     <p v-if="ipm_slot_header">{{ ipm_slot_header }}</p>
                     {{ ipm_value }}
@@ -60,16 +63,16 @@
             <div class="gallery">
               <h2>Gallery</h2>
 
-                <integer-plusminus :min="1" :max="3" :value="2"></integer-plusminus>
+                <integer-plusminus :min="1" :max="3" :value="2" :increment-aria-label="'increase by 1'" :decrement-aria-label="'decrease by 1'" :spinButtonAriaLabel="'example two'"></integer-plusminus>
                 <br/>
-                <integer-plusminus :min="0" :max="100" :step="10" v-model="demo_slot_value">
+                <integer-plusminus :min="0" :max="100" :step="10" :increment-aria-label="'increase score by 10'" :decrement-aria-label="'decrease score by 10'" :spinButtonAriaLabel="'game points'" v-model="demo_slot_value">
                     <p>You have {{ demo_slot_value }} points</p>
                     <i>Games worth 10 points</i>
                     <template slot="increment">Win</template>
                     <template slot="decrement">Loss</template>
                 </integer-plusminus>
                 <br/>
-                <integer-plusminus class="demo-vertical" :min="0" :max="9" :vertical="true" :value="5"></integer-plusminus>
+                <integer-plusminus class="demo-vertical" :min="0" :max="9" :vertical="true" :value="5" :increment-aria-label="'increase by 1'" :decrement-aria-label="'decrease by 1'" :spinButtonAriaLabel="'example 3'"></integer-plusminus>
 
 
             </div>

--- a/docs/views/Main.vue
+++ b/docs/views/Main.vue
@@ -124,6 +124,8 @@
 
     .int-pm {
         &.demo-vertical {
+            max-width: 90px;
+
             font-size: 1.5em;
             .int-pm-value {
                 background-color: black;
@@ -131,6 +133,8 @@
                 font-size: 2em;
                 padding: 0 30px !important;
                 border: 1px solid black !important;
+                line-height: 1;
+                padding: 10px;
             }
             .int-pm-btn {
                 border: none !important;

--- a/src/components/IntegerPlusminus.vue
+++ b/src/components/IntegerPlusminus.vue
@@ -150,14 +150,8 @@
 
 <style lang="scss" scoped>
     .int-pm {
-        display: table;
+        display: flex;
         text-align: center;
-        position: relative;
-
-        button {
-            display: table-cell;
-            vertical-align: middle;
-        }
 
         .int-pm-value {
             border-width: 1px 0;
@@ -187,10 +181,8 @@
         }
 
         &.int-pm-vertical {
-            display: inline-block;
-            div {
-                display: block;
-            }
+            flex-direction: column;
+
             .int-pm-value {
                 border-width: 0 1px;
                 padding: 5px 10px;


### PR DESCRIPTION
This component fits well as spinbutton as defined in the WAI-ARIA Authoring Practices 1.1
https://www.w3.org/TR/wai-aria-practices-1.1/#spinbutton

I've implemented the spinbutton pattern based on the spec and their example demo:-
https://www.w3.org/TR/wai-aria-practices-1.1/examples/spinbutton/datepicker-spinbuttons.html

Changes
---------
* Use `<button>` for keyboard focusable buttons
* Add aria label prop for buttons
* Turn .int-pm-value into a spinbutton
    - Added aria-valuenow aria-valuemin and aria-valuemax
    - Added prop for aria-label
* Added keyboard functionality as per the WAI-ARIA spec
    - `page up` and `up arrow` increment value
    - `page down` and `down arrow` decrement value
    - `home` sets value to min
    - `end` sets value to max
* Changed default styles to use flexbox instead of display: table
* Updated docs examples to include the new aria props

Testing
-------
* Tested the changes using keyboard navigation, now the buttons are using `<button>` they can be tabbed to.
* Tested using VoiceOver app on Mac. Unfortunately, the VoiceOver app seems to have some issues with the spinbutton pattern. This component now works as well as the example demo provided by w3.org (https://www.w3.org/TR/wai-aria-practices-1.1/examples/spinbutton/datepicker-spinbuttons.html)

Things to do
------------
Test the component using JAWS screenreader.